### PR TITLE
Small addition concerning URL

### DIFF
--- a/bitly/mod.bitly.php
+++ b/bitly/mod.bitly.php
@@ -19,7 +19,9 @@ class Bitly {
 	{		
 		$this->EE =& get_instance(); // Make a local reference to the ExpressionEngine super object
 		
-		$url = urlencode($this->_get_param('url'));
+		$url = $this->_get_param('url') ? $this->_get_param('url') : $this->EE->functions->fetch_current_uri();
+		$url = urlencode($url);
+		
 		$this->bitly_login = $this->_get_param('bitly_login');
 		$this->bitly_api_key = $this->_get_param('bitly_api_key');
 		


### PR DESCRIPTION
The shortened url is usually shown on the page itself, so it would make sense to have it default to the current URI if the url parameter hasn't been set.
